### PR TITLE
Fix sniffer for readonly properties

### DIFF
--- a/Kununu/Sniffs/Classes/EmptyLineAfterClassElementsSniff.php
+++ b/Kununu/Sniffs/Classes/EmptyLineAfterClassElementsSniff.php
@@ -33,7 +33,18 @@ class EmptyLineAfterClassElementsSniff implements Sniff
 
         while ($position < $scopeEnd) {
             // Find next visibility modifier or var keyword
-            $modifier = $phpcsFile->findNext([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR], $position, $scopeEnd);
+            $modifier = $phpcsFile->findNext(
+                [
+                    T_PUBLIC,
+                    T_PROTECTED,
+                    T_PRIVATE,
+                    T_VAR,
+                    T_READONLY
+                ],
+                $position,
+                $scopeEnd
+            );
+
             if ($modifier === false) {
                 break;
             }
@@ -54,7 +65,7 @@ class EmptyLineAfterClassElementsSniff implements Sniff
 
             // Check if this is a property declaration by looking for variable or type declaration
             $isProperty = false;
-            if ($tokens[$nextToken]['code'] === T_VARIABLE) {
+            if ($tokens[$nextToken]['code'] === T_VARIABLE || $tokens[$nextToken]['code'] === T_READONLY) {
                 $isProperty = true;
             } elseif ($tokens[$nextToken]['code'] === T_STRING || $tokens[$nextToken]['code'] === T_NULLABLE) {
                 // Look for variable after type declaration

--- a/tests/_data/EmptyLineAfterClassElements/after/Fixme.php
+++ b/tests/_data/EmptyLineAfterClassElements/after/Fixme.php
@@ -12,7 +12,7 @@ class Fixme
     private const string SECOND = 'second';
 
     protected string $propertyOne;
-    private int $propertyTwo;
+    private readonly int $propertyTwo;
 
     public function __invoke(string $token): void
     {

--- a/tests/_data/EmptyLineAfterClassElements/before/Fixme.php
+++ b/tests/_data/EmptyLineAfterClassElements/before/Fixme.php
@@ -11,7 +11,7 @@ class Fixme
     public const string FIRST = 'first';
     private const string SECOND = 'second';
     protected string $propertyOne;
-    private int $propertyTwo;
+    private readonly int $propertyTwo;
     public function __invoke(string $token): void
     {
         try {


### PR DESCRIPTION
# Description

The objective of this PR is to fix EmptyLineAfterClassElementsSniff having false positives for readonly properties.

