### PR TITLE
No strict yoda style will return, he will

### DIFF
--- a/dist/php-cs-fixer.php.dist
+++ b/dist/php-cs-fixer.php.dist
@@ -72,9 +72,9 @@ return (new Config())
         'void_return'                      => true,
         'yoda_style'                       => [
             'always_move_variable' => false,
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
+            'equal'                => null,
+            'identical'            => null,
+            'less_and_greater'     => null,
         ],
     ])
     ->setFinder(


### PR DESCRIPTION
The migration from kununu-scripts to here seems to have not migrated the indifference to [yoda rules](https://github.com/kununu/kununu-scripts/pull/30), so I migrate it here with the description of the PR below:

---

We prefer to leave the behavior up to the projects, i.e. if yoda style leave it if not leave it too.

The documentation of php cs is officially 

```bash
  [yoda_style] Rule must be enabled (true), disabled (false) or configured (non-empty, assoc array). Other values are not allowed. To disable the rule, use "FALSE" instead of "NULL".
```

The configuration here is a more explicit version of `false`.