### PR TITLE
Architecture Sniffer: Fixing namespace regex

### DIFF
--- a/Kununu/ArchitectureSniffer/Configuration/Selector/RegexTrait.php
+++ b/Kununu/ArchitectureSniffer/Configuration/Selector/RegexTrait.php
@@ -12,6 +12,10 @@ trait RegexTrait
                 $path = substr($path, 1);
             }
 
+            if (str_ends_with($path, '\\')) {
+                $path = substr($path, 0, -1);
+            }
+
             $path = str_replace('\\', '\\\\', $path);
 
             return '/' . str_replace('*', '.+', $path) . '/';


### PR DESCRIPTION
fqcn is only treated as namespace if the string ends with backslash, for the phpat selector it should not end with backslash though