### PR TITLE
Fix CsFixerGitHookCommand

### DIFF
--- a/Kununu/CsFixer/Command/CsFixerGitHookCommand.php
+++ b/Kununu/CsFixer/Command/CsFixerGitHookCommand.php
@@ -42,11 +42,11 @@ final class CsFixerGitHookCommand extends BaseCommand
 
             $io->success('PHP CS Fixer Git pre‑commit hook installed successfully.');
 
-            return self::SUCCESS;
+            return 0;
         } catch (Throwable $e) {
             $io->error('Installation failed: ' . $e->getMessage());
 
-            return self::FAILURE;
+            return 1;
         }
     }
 


### PR DESCRIPTION
# Description

The objective of this PR is to fix errors being reported both locally and in the pipelines when running the git hook install command.

## Details
- Fix `[ERROR] Installation failed: Undefined constant Symfony\Component\Console\Command\Command::SUCCESS`
    - As a temporary fix until we can figure out why we will not use those constants on that command

<img width="1911" height="641" alt="image" src="https://github.com/user-attachments/assets/35afa727-d141-48de-9220-824e098c8c17" />
