### PR TITLE
[hotfix] unknown constants when executed with composer 2.2

### DIFF
--- a/Kununu/CsFixer/Command/CsFixerCommand.php
+++ b/Kununu/CsFixer/Command/CsFixerCommand.php
@@ -14,6 +14,9 @@ use Throwable;
 
 final class CsFixerCommand extends BaseCommand
 {
+    public const int SUCCESS = 0;
+    public const int FAILURE = 1;
+
     private const string ARGUMENT_FILES = 'files';
     private const string OPTION_CONFIG = 'config';
     private const string OPTION_EXTRA_ARGS = 'extra-args';

--- a/Kununu/CsFixer/Command/CsFixerGitHookCommand.php
+++ b/Kununu/CsFixer/Command/CsFixerGitHookCommand.php
@@ -13,6 +13,9 @@ use Throwable;
 
 final class CsFixerGitHookCommand extends BaseCommand
 {
+    public const int SUCCESS = 0;
+    public const int FAILURE = 1;
+
     protected function configure(): void
     {
         $this
@@ -42,11 +45,11 @@ final class CsFixerGitHookCommand extends BaseCommand
 
             $io->success('PHP CS Fixer Git pre‑commit hook installed successfully.');
 
-            return 0;
+            return self::SUCCESS;
         } catch (Throwable $e) {
             $io->error('Installation failed: ' . $e->getMessage());
 
-            return 1;
+            return self::FAILURE;
         }
     }
 


### PR DESCRIPTION
<!-- --------------------------------------- -->
# Description

The objective of this PR is to add constants which were supposed to be inherited but can't in older versions of `symfony/console`.

<!-- If applicable (e.g. describing commands, etc.) use this section, otherwise remove it -->
## Details
<!-- --------------------------------------- -->
In this package we're registering two composer commands:
```
kununu
  kununu:cs-fixer           Applies PHP CS Fixer on specified files or directories.
  kununu:cs-fixer-git-hook  Installs PHP CS Fixer as a Git pre-commit hook.
```

When these are run, they are executed by the composer binary (composer.phar).
Example:
```
#0 phar:///usr/local/bin/composer/vendor/symfony/console/Command/Command.php(245): Kununu\CsFixer\Command\CsFixerCommand->execute()
#1 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(835): Symfony\Component\Console\Command\Command->run()
#2 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(185): Symfony\Component\Console\Application->doRunCommand()
#3 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(336): Symfony\Component\Console\Application->doRun()
#4 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(117): Composer\Console\Application->doRun()
#5 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(131): Symfony\Component\Console\Application->run()
#6 phar:///usr/local/bin/composer/bin/composer(95): Composer\Console\Application->run()
#7 /usr/local/bin/composer(29): require('...')
```

In our services we deliberately use the LTS version 2.2. This version builds on a rather old version of `symfony/console`, see https://github.com/composer/composer/blob/2.2.25/composer.json#L35C30-L35C36. In that version, the `Symfony\Console\Command\Command` class did not yet define constants for return values, see https://github.com/symfony/console/blob/v2.8.52/Command/Command.php
However, when developing with an IDE like PHPstorm we were tricked into believing that the constants exist because `symfony/console` might be installed in a newer version locally or within a service.