### PR TITLE
docs: add kun-init 4-file documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository. For install and usage see `README.md`; for dev workflow see `CONTRIBUTING.md`.
+
+## What this is
+
+`kununu/code-tools` is a shared dev-tooling package (`composer-plugin`) consumed by most kununu PHP repositories. It centralises static-analysis and code-style configuration and ships a `code-tools` binary that publishes those configs into consuming projects.
+
+## Bundled tools
+
+- PHP-CS-Fixer, PHP_CodeSniffer (with custom `Kununu` sniffs), Psalm, PHPStan, Rector.
+- Architecture Sniffer, built on PHPAT, for architecture/dependency rules.
+- `bin/code-tools`: publishes `dist/*.dist` configs into a consuming project.
+- `bin/php-in-k8s`: runs PHP commands inside a local Kubernetes pod.
+
+## Code layout
+
+- `Kununu/` — PSR-4 source (`Kununu\` namespace): `CsFixer/` (composer plugin, command, git hook, provider), `Sniffs/` (custom PHP_CodeSniffer sniffs), `ArchitectureSniffer/`.
+- `bin/` — the `code-tools` and `php-in-k8s` executables.
+- `dist/` — `*.dist` config templates published into consuming projects.
+- `docs/` — per-tool deep documentation, one folder per tool.
+- `tests/` — PHPUnit tests under `tests/Unit/`, mirroring the `Kununu/` tree.
+
+## Conventions
+
+- `declare(strict_types=1);` in every PHP file.
+- Follow the repo's own PHP-CS-Fixer and PHP_CodeSniffer rulesets; changes must stay clean under both.
+- Custom sniffs live under `Kununu\Sniffs`; register them in `Kununu/Sniffs/ruleset.xml`.
+- Tests mirror the source namespace under `tests/Unit/`.
+- PHP version is pinned in `composer.json` (`require.php`).
+
+## Quality gates
+
+Run `composer ci-checks` (cs-fixer, code sniffer, PHPStan, Rector, Psalm, PHPUnit). PHPStan runs at max level and Psalm must pass with no cache. See `scripts` in `composer.json` for individual commands and `CONTRIBUTING.md` for details.
+
+## Hard constraints
+
+- Do not edit `vendor/`.
+- Do not hardcode tool versions in docs; reference `composer.json`.
+- Changes to `dist/*.dist` affect every consuming repo — treat them as public API.
+- Keep the `code-tools` binary interface backward compatible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+How to develop, test, and ship changes to `kununu/code-tools`.
+
+## Development setup
+
+Requires PHP as pinned in `composer.json` (`require.php`) and Composer.
+
+```console
+composer install
+```
+
+## Testing
+
+Run the unit test suite:
+
+```console
+composer test-unit
+```
+
+## Quality checks
+
+Run the full check suite before opening a PR:
+
+```console
+composer ci-checks
+```
+
+This runs PHP-CS-Fixer, PHP_CodeSniffer, PHPStan, Rector, Psalm, and PHPUnit. Auto-fixers are available for style and refactors:
+
+```console
+composer cs-fixer-fix
+composer cs-fix
+composer rector-fix
+```
+
+See the `scripts` section of `composer.json` for the complete list of commands.
+
+## Pull requests
+
+- Branch from `main`.
+- Fill in `.github/PULL_REQUEST_TEMPLATE.md`, including the linked JIRA issue.
+- Ensure CI is green; the Continuous Integration workflow runs the checks above plus composer dependency and normalization checks, and reports coverage to SonarCloud.
+- `@kununu/backend-libraries` is the code owner and reviews all changes.
+
+## Releasing
+
+The package is distributed via Composer and versioned with Git tags following SemVer. Because most kununu PHP repos depend on this package, and `dist/*.dist` templates and the `code-tools` binary form its public API, treat any change to them as breaking unless proven otherwise.

--- a/Kununu/ArchitectureSniffer/Helper/TypeChecker.php
+++ b/Kununu/ArchitectureSniffer/Helper/TypeChecker.php
@@ -22,13 +22,7 @@ final readonly class TypeChecker
             return false;
         }
 
-        foreach ($arr as $item) {
-            if (!is_string($item)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($arr, static fn($item) => is_string($item));
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ composer require --dev kununu/code-tools --no-plugins
 - [bin/code-tools](docs/CodeTools/README.md) instructions.
 - [bin/php-in-k8s](docs/PhpInK8s/README.md) instructions.
 - [Architecture Sniffer & PHPAT](docs/ArchitectureSniffer/README.md) instructions.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and the PR/release process.

--- a/rector.php
+++ b/rector.php
@@ -15,6 +15,7 @@ return RectorConfig::configure()
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,
         __DIR__ . '/tests/bootstrap.php',
+        __DIR__ . '/tests/_data',
         __DIR__ . '/rector.php',
     ])
     ->withImportNames();


### PR DESCRIPTION
### JIRA issue
[KUNAI-8](https://new-work.atlassian.net/browse/KUNAI-8)

# Description

The objective of this PR is to add the standard kun-init 4-file documentation structure to this repository, with strict ownership and no duplicated content.

## Details

- **README.md** — humans + agents. Existing consumer-facing content kept; added a `## Contributing` section linking `CONTRIBUTING.md`.
- **AGENTS.md** — agents only. What the package is, the tools it bundles, code layout, conventions, quality gates, and hard constraints.
- **CONTRIBUTING.md** — humans + agents. Owns all development workflow: setup, testing, quality checks, PR and release process.
- **CLAUDE.md** — points to `@AGENTS.md`.


[KUNAI-8]: https://kununu-team.atlassian.net/browse/KUNAI-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ