### PR TITLE
Use vimeo/psalm 6.x branch as version 6.16 to allow co-existence with PHPUnit 13.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "symfony/console": "^6.4 || ^7.4",
     "symfony/process": "^6.4 || ^7.4",
     "symfony/yaml": "^6.4 || ^7.4",
-    "vimeo/psalm": "^6.16"
+    "vimeo/psalm": "6.x-dev as 6.16"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.50",


### PR DESCRIPTION
# Description

The objective of this PR is to use the 6.x branch of psalm, because latest 6.x published version does not yet incorporated the changes to support `sebastian/diff:^9` which breaks the update of PHPUnit to ^13.2